### PR TITLE
Add spreadsheet for data exploration

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import pandas as pd
 import plotly.express as px
+from mitosheet.streamlit.v1 import spreadsheet
 
 def fig1_daily(sub, selected_item, axis_title):
     # Time series plot
@@ -211,8 +212,7 @@ if selected_type1 == 'Price Index':
     raw_data = pd.concat([subindices[["date", selected_item1]], main_index[[main_index.columns[1], selected_item2]]], axis=1)
 else:
     raw_data = pd.concat([subprices[["date", selected_item1]], main_index[[main_index.columns[1], selected_item2]]], axis=1)
-# convert datetime to date
-raw_data['date'] = raw_data['date'].dt.date
-if st.checkbox('Show raw data'):
+
+if st.checkbox('Explore raw data'):
     st.subheader('Raw data')
-    st.write(raw_data)
+    spreadsheet(raw_data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 pandas
 plotly
+mitosheet


### PR DESCRIPTION
This PR adds a spreadsheet to the Streamlit app to help users explore the underlying data. 

For example, in the video below, I used the spreadsheet to build a new graph to understand how the yearly average CEFIS Food Price index compared to the yearly average Turkstat Food Index. 

@Soybilgen let me know what you think of this PR. Happy to add more documentation, change the location of the spreadsheet in the app, etc. 

https://github.com/Soybilgen/CEFIS-Food-Indices/assets/18709905/abc1a7ec-dbc8-4672-923b-b841165c8578

